### PR TITLE
Fix wrongly calculated position in pixels of the first snap position

### DIFF
--- a/lib/snapping_sheet.dart
+++ b/lib/snapping_sheet.dart
@@ -1,6 +1,7 @@
 library snapping_sheet;
 
 import 'dart:math';
+
 import 'package:flutter/widgets.dart';
 
 enum SnappingSheetType { manuel, fixed, fit }
@@ -381,8 +382,8 @@ class _SnappingSheetState extends State<SnappingSheet>
         if (widget.lockOverflowDrag) {
           var newDragAmount = _currentDragAmount - dragEvent.delta.dy;
           if (newDragAmount <
-              widget.snapPositions.first
-                  ._getPositionInPixels(_currentConstraints.maxHeight)) {
+              widget.snapPositions.first._getPositionInPixels(
+                  _currentConstraints.maxHeight - widget.grabbingHeight)) {
             return;
           }
 


### PR DESCRIPTION
I believe we have to subtract the `grabbingHeight` from the `_currentConstraints.maxHeight` in order to calculate the correct pixel position of the first `SnapPosition`, just as the function `_getSnapPositionInPixels` does.

```dart
  /// Getting the snap position in pixels
  double _getSnapPositionInPixels(SnapPosition snapPosition) {
    return snapPosition._getPositionInPixels(
        _currentConstraints.maxHeight - widget.grabbingHeight);
  }
```