### PR TITLE
Remove unwanted debug output

### DIFF
--- a/lib/src/scroll_controller_override.dart
+++ b/lib/src/scroll_controller_override.dart
@@ -119,9 +119,6 @@ class _ScrollControllerOverrideState extends State<ScrollControllerOverride> {
   @override
   Widget build(BuildContext context) {
     return Listener(
-      onPointerDown: (_) {
-        print("Test");
-      },
       onPointerMove: (dragEvent) {
         _setDragDirection(dragEvent.delta.dy);
         _setLockPosition();


### PR DESCRIPTION
The `print('Test');` does not seem to be required for production use...