### PR TITLE
Allow constraining sheet content to the maximum expanded sheet size

### DIFF
--- a/lib/src/sheet_content_wrapper.dart
+++ b/lib/src/sheet_content_wrapper.dart
@@ -66,7 +66,8 @@ class _SheetContentWrapperState extends State<SheetContentWrapper> {
   Widget build(BuildContext context) {
     if (widget.sheetData == null) return SizedBox();
     return widget.sizeCalculator.positionWidget(
-      child: _wrapWithNecessaryWidgets(widget.sheetData!.child),
+      child: _wrapWithNecessaryWidgets(widget.sheetData!
+          .buildConstrainedChild(widget.sizeCalculator.maxHeight)),
     );
   }
 }

--- a/lib/src/sheet_size_behaviors.dart
+++ b/lib/src/sheet_size_behaviors.dart
@@ -4,7 +4,14 @@ abstract class SheetSizeBehavior {
 
 /// Fills the available hight in a sheet.
 class SheetSizeFill implements SheetSizeBehavior {
-  const SheetSizeFill();
+  /// If set to `true`, the [SnappingSheetContent.child] will be constrained
+  /// to the sheet's visible area as it expands.
+  ///
+  /// Otherwise, it will be constrained to the maximum size that the sheet can
+  /// expand to, and clipped.
+  final bool constrainToVisibleArea;
+
+  const SheetSizeFill({this.constrainToVisibleArea = true});
 }
 
 /// Make the sheet have a static height.

--- a/lib/src/snapping_sheet_content.dart
+++ b/lib/src/snapping_sheet_content.dart
@@ -33,14 +33,22 @@ class SnappingSheetContent {
     this.childScrollController,
   }) : this._child = child;
 
-  double? _getHeight() {
+  double? _getHeight(double maxHeight) {
     var sizeBehavior = this.sizeBehavior;
     if (sizeBehavior is SheetSizeStatic) return sizeBehavior.height;
+    if (sizeBehavior is SheetSizeFill && !sizeBehavior.constrainToVisibleArea)
+      return maxHeight;
   }
 
-  Widget get child {
-    return SizedBox(
-      height: _getHeight(),
+  Widget buildConstrainedChild(double maxHeight) {
+    assert(location != SheetLocation.unknown,
+        'The location must be known to constrain the child!');
+    return OverflowBox(
+      alignment: location == SheetLocation.above
+          ? Alignment.bottomCenter
+          : Alignment.topCenter,
+      minHeight: _getHeight(maxHeight),
+      maxHeight: _getHeight(maxHeight),
       child: this._child,
     );
   }


### PR DESCRIPTION
This PR adds a `constrainToVisibleArea` field to `SheetSizeFill`. When this field is set to `false`, the `SnappingSheetContent` with the behaviour will constrain its child to the constrains of the sheet in its completely expanded form.

This allows non-scrolling content to slide up, as the sheet will truly slide up instead of expand.