### PR TITLE
Added respext max height to Snapping Position

### DIFF
--- a/lib/src/snapping_position.dart
+++ b/lib/src/snapping_position.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/widgets.dart';
 
 /// This class is an helper class for specifying the [grabbingContentOffset]
@@ -47,12 +49,16 @@ class SnappingPosition {
   /// The snapping duration
   final Duration snappingDuration;
 
+  /// Whether to respect max height when snapping to new position via pixels
+  final bool respectMaxHeight;
+
   /// Creates a snapping position that is given by the amount of pixels
   const SnappingPosition.pixels({
     required double positionPixels,
     this.snappingCurve = Curves.ease,
     this.snappingDuration = const Duration(milliseconds: 250),
     this.grabbingContentOffset = GrabbingContentOffset.middle,
+    this.respectMaxHeight = false,
   })  : this._positionPixel = positionPixels,
         this._positionFactor = null;
 
@@ -65,7 +71,8 @@ class SnappingPosition {
     this.snappingDuration = const Duration(milliseconds: 250),
     this.grabbingContentOffset = GrabbingContentOffset.middle,
   })  : this._positionPixel = null,
-        this._positionFactor = positionFactor;
+        this._positionFactor = positionFactor,
+        this.respectMaxHeight = false;
 
   double getPositionInPixels(double maxHeight, double grabbingHeight) {
     var centerPosition = this._getCenterPositionInPixels(maxHeight);
@@ -74,7 +81,10 @@ class SnappingPosition {
   }
 
   double _getCenterPositionInPixels(double maxHeight) {
-    if (this._positionPixel != null) return this._positionPixel!;
+    if (this._positionPixel != null) {
+      if (respectMaxHeight) return min(maxHeight, this._positionPixel!);
+      return this._positionPixel!;
+    }
     return this._positionFactor! * maxHeight;
   }
 

--- a/test/snapping_position_test.dart
+++ b/test/snapping_position_test.dart
@@ -84,6 +84,14 @@ void main() {
       );
       expect(snappingPosition.getPositionInPixels(1000, 100), 1200);
     });
+    test('Testing respect max height', () {
+      var snappingPosition = SnappingPosition.pixels(
+        positionPixels: 1200,
+        grabbingContentOffset: GrabbingContentOffset.middle,
+        respectMaxHeight: true,
+      );
+      expect(snappingPosition.getPositionInPixels(1000, 100), 1000);
+    });
     test('Testing undershoot position', () {
       var snappingPosition = SnappingPosition.pixels(
         positionPixels: -1200,


### PR DESCRIPTION
It would be nice to have this feature so when the user wants to set a new position via pixels, he doesn't need to worry about being above max height.