### PR TITLE
support for hot reload and hot restart

### DIFF
--- a/lib/src/snapping_sheet_widget.dart
+++ b/lib/src/snapping_sheet_widget.dart
@@ -334,6 +334,9 @@ class _SnappingSheetState extends State<SnappingSheet>
 
   @override
   Widget build(BuildContext context) {
+    if (widget.controller != null) {
+      widget.controller!._attachState(this);
+    }
     return LayoutBuilder(
       builder: (context, constraints) {
         _latestConstraints = constraints;


### PR DESCRIPTION
After hot restart/hot reload, a new controller instance of SnappingSheetController is passed, but not updated. It causes "was called on null" error.