### PR TITLE
Bug fix: Can not attach SnappingSheetController #63

### DIFF
--- a/lib/src/snapping_sheet_widget.dart
+++ b/lib/src/snapping_sheet_widget.dart
@@ -334,6 +334,9 @@ class _SnappingSheetState extends State<SnappingSheet>
 
   @override
   Widget build(BuildContext context) {
+    if (widget.controller != null) {
+      widget.controller!._attachState(this);
+    }
     return LayoutBuilder(
       builder: (context, constraints) {
         _latestConstraints = constraints;


### PR DESCRIPTION
```
import 'package:flutter/material.dart';
import 'package:snapping_sheet/snapping_sheet.dart';

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
// This widget is the root of your application.
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(

        primarySwatch: Colors.blue,
      ),
      home: MyHomePage(title: 'Flutter Demo Home Page'),
    );
  }
}

class MyHomePage extends StatefulWidget {
  MyHomePage({Key? key, required this.title}) : super(key: key);

  final String title;

  @override
  _MyHomePageState createState() => _MyHomePageState();
}

class _MyHomePageState extends State<MyHomePage> {

  @override
  Widget build(BuildContext context) {

    SnappingSheetController snappingSheetController = SnappingSheetController();
    return Scaffold(
      appBar: AppBar(

        title: Text(widget.title),
      ),
      body: SnappingSheet(
        // Connect it to the SnappingSheet
        controller: snappingSheetController,

        grabbingHeight: 200,
        grabbing: GestureDetector(
          onTap: (){
            print('Controller is working now!');
            snappingSheetController.snapToPosition(
              SnappingPosition.factor(positionFactor: 0.75),
            );
          },
          child: Container(
              height: 200,
              color: Colors.blue
          ),
        ),
        sheetBelow: SnappingSheetContent(
          draggable: true,
          child: Container(color: Colors.red),
        ),
      ), // This trailing comma makes auto-formatting nicer for build methods.
    );
  }
}
```